### PR TITLE
OGImageをローカルに保存して参照する

### DIFF
--- a/src/components/blog-parts.tsx
+++ b/src/components/blog-parts.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import Link from 'next/link'
-import Image from 'next/image'
 
 import NotionBlock from './notion-block'
 import * as interfaces from '../lib/notion/interfaces'
@@ -21,7 +20,12 @@ export const PostDate = ({ post }) => (
 export const PostThumbnail = ({ post }) => (
   <div className={styles.thumbnail}>
     <Link href="/blog/[slug]" as={getBlogLink(post.Slug)} passHref>
-      <Image src={post.OGImage} width={500} height={250} />
+      <img
+        src={`/notion_images/${post.PageId}.png`}
+        width={500}
+        height={250}
+        alt="thumbnail"
+      />
     </Link>
   </div>
 )

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -100,7 +100,7 @@ const RenderPost = ({
       <DocumentHead
         title={post.Title}
         description={post.Excerpt}
-        urlOgImage={post.OGImage}
+        urlOgImage={`/notion_images/${post.PageId}.png`}
       />
 
       <div className={styles.mainContent}>

--- a/src/pages/blog/before/[date].tsx
+++ b/src/pages/blog/before/[date].tsx
@@ -20,6 +20,7 @@ import stylesParts from '../../../styles/blog-parts.module.css'
 import styles from '../../../styles/blog.module.css'
 
 import { getBeforeLink } from '../../../lib/blog-helpers'
+import * as imageCache from '../../../lib/notion/image-cache'
 import {
   getPosts,
   getRankedPosts,
@@ -37,6 +38,8 @@ export async function getStaticProps({ params: { date } }) {
   const firstPost = await getFirstPost()
   const rankedPosts = await getRankedPosts()
   const tags = await getAllTags()
+
+  posts.forEach(p => p.OGImage && imageCache.store(p.PageId, p.OGImage))
 
   return {
     props: {

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -19,12 +19,15 @@ import {
   getRankedPosts,
   getAllTags,
 } from '../../lib/notion/client'
+import * as imageCache from '../../lib/notion/image-cache'
 
 export async function getStaticProps() {
   const posts = await getPosts()
   const firstPost = await getFirstPost()
   const rankedPosts = await getRankedPosts()
   const tags = await getAllTags()
+
+  posts.forEach(p => p.OGImage && imageCache.store(p.PageId, p.OGImage))
 
   return {
     props: {

--- a/src/pages/blog/tag/[tag].tsx
+++ b/src/pages/blog/tag/[tag].tsx
@@ -22,6 +22,7 @@ import {
   getPostsByTag,
   getAllTags,
 } from '../../../lib/notion/client'
+import * as imageCache from '../../../lib/notion/image-cache'
 
 export async function getStaticProps({ params: { tag } }) {
   const posts = await getPostsByTag(tag)
@@ -38,6 +39,8 @@ export async function getStaticProps({ params: { tag } }) {
       revalidate: 30,
     }
   }
+
+  posts.forEach(p => p.OGImage && imageCache.store(p.PageId, p.OGImage))
 
   return {
     props: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -72,7 +72,7 @@ const RenderPage = ({ rankedPosts = [], tags = [] }) => (
           }
         })}
         <div className={styles.moreSearch}>
-          <Link href="/blog">
+          <Link href="/blog" passHref>
             <p> 🔍　to Blog List </p>
           </Link>
         </div>


### PR DESCRIPTION
Vercel の Source Images 対策で記事一覧画面の `next/image` を `img` タグに置き換えました。

`next/image` では要素の大きさに合わせて画像が縮小されていましたが `img` タグになったことで親要素からはみ出してしまうケースがあります。
CSSはご自身で調整していただければと思います。

![スクリーンショット 2022-03-10 13 12 06](https://user-images.githubusercontent.com/1063435/157622972-c31ab01a-b798-4a2d-b639-6fb1fb78ec70.png)