### PR TITLE
OG画像のURL修正

### DIFF
--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -100,7 +100,10 @@ const RenderPost = ({
       <DocumentHead
         title={post.Title}
         description={post.Excerpt}
-        urlOgImage={`/notion_images/${post.PageId}.png`}
+        urlOgImage={new URL(
+          `/notion_images/${post.PageId}.png`,
+          NEXT_PUBLIC_URL
+        ).toString()}
       />
 
       <div className={styles.mainContent}>


### PR DESCRIPTION
og-imageのURLはフルパス (https:// から始まる) である必要があるのですが `/notion_images/` から始まる相対パスになっていました。